### PR TITLE
Pass model weights to the auxiliary treatment regression in covariate benchmarks

### DIFF
--- a/R/ovb_bounds.R
+++ b/R/ovb_bounds.R
@@ -347,7 +347,12 @@ ovb_partial_r2_bound.lm <- function(model,
   keep   <- !(colnames(m) %in% treatment)
   d      <- m[,treatment]
   XX     <- m[, keep, drop = FALSE]
-  treatment_model <- lm(d ~ XX + 0)
+  # carry the model's weights into the auxiliary treatment regression (WLS)
+  if (is.null(model$weights)) {
+    treatment_model <- lm(d ~ XX + 0)
+  } else {
+    treatment_model <- lm(d ~ XX + 0, weights = model$weights)
+  }
   treatment_model
 
   # treatment_model <- lm.fit(y = m[,treatment, drop = F], x = m[,keep])
@@ -448,11 +453,22 @@ ovb_partial_r2_bound.fixest <- function(model,
 
   # vcov <- model$call$vcov
 
-  if (!is.null(model$fixef_id)) {
-    fixef_df <- data.frame(model$fixef_id[1:length(model$fixef_id)])
-    treatment_model <- fixest::feols.fit(y = d, X = XX, fixef_df = fixef_df)
+  # carry the model's weights into the auxiliary treatment regression (WLS).
+  # feols.fit() errors on weights = NULL, so branch instead of always passing it.
+  if (is.null(model$weights)) {
+    if (!is.null(model$fixef_id)) {
+      fixef_df <- data.frame(model$fixef_id[1:length(model$fixef_id)])
+      treatment_model <- fixest::feols.fit(y = d, X = XX, fixef_df = fixef_df)
+    } else {
+      treatment_model <- fixest::feols.fit(y = d, X = XX)
+    }
   } else {
-    treatment_model <- fixest::feols.fit(y = d, X = XX)
+    if (!is.null(model$fixef_id)) {
+      fixef_df <- data.frame(model$fixef_id[1:length(model$fixef_id)])
+      treatment_model <- fixest::feols.fit(y = d, X = XX, fixef_df = fixef_df, weights = model$weights)
+    } else {
+      treatment_model <- fixest::feols.fit(y = d, X = XX, weights = model$weights)
+    }
   }
 
   # treatment_model <- lm.fit(y = m[,treatment, drop = F], x = m[,keep])

--- a/tests/testthat/test-25-weighted-bounds.R
+++ b/tests/testthat/test-25-weighted-bounds.R
@@ -1,0 +1,51 @@
+context("Weighted (WLS) benchmark bounds")
+
+# A weighted regression and its frequency-expanded (row-replicated) unweighted
+# counterpart are numerically the same regression, so ovb_bounds() must return
+# the same benchmark bounds for both. Before the weights fix it did not: the
+# internal auxiliary treatment regression in ovb_partial_r2_bound() dropped the
+# model's weights, so the benchmark's partial R2 with the treatment (r2dz.x) --
+# and hence the bounds and adjusted estimates -- were computed unweighted.
+
+test_that("ovb_bounds respects lm() weights", {
+  data("darfur")
+  set.seed(1)
+  darfur$wts <- sample(1:4, nrow(darfur), replace = TRUE)   # integer weights
+  fml <- peacefactor ~ directlyharmed + age + farmer_dar + herder_dar +
+    pastvoted + hhsize_darfur + female + village
+
+  model_w <- lm(fml, data = darfur, weights = wts)
+  model_e <- lm(fml, data = darfur[rep(seq_len(nrow(darfur)), darfur$wts), ])
+
+  # single-covariate benchmark
+  bw <- ovb_bounds(model_w, "directlyharmed", benchmark_covariates = "female")
+  be <- ovb_bounds(model_e, "directlyharmed", benchmark_covariates = "female")
+  expect_equal(bw$r2dz.x,            be$r2dz.x,            tolerance = 1e-6)
+  expect_equal(bw$r2yz.dx,           be$r2yz.dx,           tolerance = 1e-6)
+  expect_equal(bw$adjusted_estimate, be$adjusted_estimate, tolerance = 1e-6)
+
+  # grouped benchmark
+  gw <- ovb_bounds(model_w, "directlyharmed",
+                   benchmark_covariates = list(grp = c("female", "age")))
+  ge <- ovb_bounds(model_e, "directlyharmed",
+                   benchmark_covariates = list(grp = c("female", "age")))
+  expect_equal(gw$r2dz.x,            ge$r2dz.x,            tolerance = 1e-6)
+  expect_equal(gw$adjusted_estimate, ge$adjusted_estimate, tolerance = 1e-6)
+})
+
+test_that("ovb_bounds respects fixest weights", {
+  skip_if_not_installed("fixest")
+  data("darfur")
+  set.seed(1)
+  darfur$wts <- sample(1:4, nrow(darfur), replace = TRUE)
+  fml <- peacefactor ~ directlyharmed + age + farmer_dar + herder_dar +
+    pastvoted + hhsize_darfur + female | village
+
+  model_w <- fixest::feols(fml, data = darfur, weights = ~wts)
+  model_e <- fixest::feols(fml, data = darfur[rep(seq_len(nrow(darfur)), darfur$wts), ])
+
+  bw <- ovb_bounds(model_w, "directlyharmed", benchmark_covariates = "female")
+  be <- ovb_bounds(model_e, "directlyharmed", benchmark_covariates = "female")
+  expect_equal(bw$r2dz.x,            be$r2dz.x,            tolerance = 1e-5)
+  expect_equal(bw$adjusted_estimate, be$adjusted_estimate, tolerance = 1e-5)
+})


### PR DESCRIPTION
`ovb_partial_r2_bound()` fits an auxiliary regression of the treatment on the other covariates to get the benchmark covariate's partial R² with the treatment (`r2dz.x`). Currently this does not inherit weights from the original regression passed by the user, resulting in potentially inaccurate benchmark values. When weights are included in the user-provided regression, all other statistics (correctly) use values from the weighted regression.

Fix: carry `model$weights` into the auxiliary regression, in the lm and fixest methods. `feols.fit()` errors on `weights = NULL`, so the `fixest` method keeps the original unweighted call when the model has no weights; unweighted models are unaffected.

Test added: `tests/testthat/test-25-weighted-bounds.R`: a weighted fit and its frequency-expanded unweighted equivalent must give identical bounds.
