### PR TITLE
Derive the non-iid note from the fitted vcov, and emit it once per call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ inst/doc
 .Rd2pdf54514/Rd2.tex
 .Ruserdata
 tests/testthat/Rplots.pdf
+Rplots.pdf

--- a/R/bias_functions.R
+++ b/R/bias_functions.R
@@ -215,12 +215,7 @@ adjusted_se.lm <- function(model, treatment,  r2dz.x, r2yz.dx, ...){
 adjusted_se.fixest <- function(model, treatment,  r2dz.x, r2yz.dx, message = TRUE, ...){
   # extract model data
   if(message){
-    vcov_type <- model$call$vcov
-    if(!is.null(vcov_type)){
-      if(vcov_type!= "iid"){
-        message("Note for fixest: using 'iid' standard errors. Support for robust standard errors coming soon.")
-      }
-    }
+    message_vcov.fixest(model)
   }
   model_data <- model_helper.fixest(model, covariates = treatment)
   new_se <- with(model_data, adjusted_se.numeric(se = se, dof = dof, r2dz.x = r2dz.x, r2yz.dx = r2yz.dx))
@@ -262,12 +257,7 @@ adjusted_ci.fixest <- function(model, treatment,  r2dz.x, r2yz.dx,
                                which = c("both", "lwr", "upr"),
                                reduce = TRUE, alpha = 0.05, message = T, ...){
   if(message){
-    vcov_type <- model$call$vcov
-    if(!is.null(vcov_type)){
-      if(vcov_type!= "iid"){
-        message("Note for fixest: using 'iid' standard errors. Support for robust standard errors coming soon.")
-      }
-    }
+    message_vcov.fixest(model)
   }
   # extract model data
   model_data <- model_helper.fixest(model, covariates = treatment)
@@ -341,12 +331,7 @@ adjusted_t.lm <- function(model, treatment,  r2dz.x, r2yz.dx, reduce = TRUE, h0 
 #' @export
 adjusted_t.fixest <- function(model, treatment,  r2dz.x, r2yz.dx, reduce = TRUE, h0 = 0, message = T, ...){
   if(message){
-    vcov_type <- model$call$vcov
-    if(!is.null(vcov_type)){
-      if(vcov_type!= "iid"){
-        message("Note for fixest: using 'iid' standard errors. Support for robust standard errors coming soon.")
-      }
-    }
+    message_vcov.fixest(model)
   }
   # extract model data
   model_data <- model_helper.fixest(model, covariates = treatment)

--- a/R/ovb_bounds.R
+++ b/R/ovb_bounds.R
@@ -142,6 +142,9 @@ ovb_bounds.fixest <- function(model,
 
   bound = match.arg(bound)
 
+  # emitted once here, rather than once per adjusted_* call below
+  if (message) message_vcov.fixest(model)
+
   bounder = switch(bound,
                    "partial r2" = ovb_partial_r2_bound,
                    "partial r2 no D" = stop("Only partial r2 implemented now."),
@@ -167,7 +170,7 @@ ovb_bounds.fixest <- function(model,
                                      treatment = treatment,
                                      r2yz.dx = bounds$r2yz.dx,
                                      r2dz.x = bounds$r2dz.x,
-                                     message = message)
+                                     message = FALSE)
 
     bounds$adjusted_t = adjusted_t.fixest(model = model,
                                    treatment = treatment,
@@ -175,7 +178,7 @@ ovb_bounds.fixest <- function(model,
                                    r2dz.x = bounds$r2dz.x,
                                    h0 = h0,
                                    reduce = reduce,
-                                   message = message)
+                                   message = FALSE)
 
     se_multiple <- qt(alpha/2, df = fixest::degrees_freedom(model, type = "resid", vcov = "iid"), lower.tail = F)
     bounds$adjusted_lower_CI <- bounds$adjusted_estimate - se_multiple*bounds$adjusted_se

--- a/tests/testthat/test-25-vcov-message.R
+++ b/tests/testthat/test-25-vcov-message.R
@@ -1,0 +1,92 @@
+context("Non-iid vcov note for fixest models")
+
+data("darfur")
+
+fml <- peacefactor ~ directlyharmed + age + farmer_dar + herder_dar +
+  pastvoted + hhsize_darfur + female + village
+
+feols.iid <- fixest::feols(fml, data = darfur)
+feols.hc1 <- fixest::feols(fml, data = darfur, vcov = "hetero")
+
+# =========================================================================
+# The note must reach the entry points users actually call.
+# These two paths had no coverage, which is why a silent regression in
+# message_vcov.fixest() went unnoticed on 8 of 9 CI jobs.
+# =========================================================================
+
+test_that("sensemakr.fixest emits the note for a non-iid vcov", {
+  expect_message(sensemakr(feols.hc1, treatment = "directlyharmed"), "iid")
+})
+
+test_that("sensitivity_stats.fixest emits the note for a non-iid vcov", {
+  expect_message(sensitivity_stats(feols.hc1, treatment = "directlyharmed"), "iid")
+  expect_silent(sensitivity_stats(feols.hc1, treatment = "directlyharmed",
+                                  message = FALSE))
+})
+
+test_that("no note is emitted for an iid model", {
+  expect_silent(sensemakr(feols.iid, treatment = "directlyharmed"))
+  expect_silent(sensitivity_stats(feols.iid, treatment = "directlyharmed"))
+  expect_silent(robustness_value(feols.iid, covariates = "directlyharmed"))
+  expect_silent(adjusted_se(feols.iid, treatment = "directlyharmed",
+                            r2dz.x = 0.05, r2yz.dx = 0.05))
+})
+
+# =========================================================================
+# The note is derived from what fixest actually computed, not from the
+# unevaluated call. Passing vcov through a variable, as the formula methods
+# do internally, must not be mistaken for a non-iid vcov.
+# =========================================================================
+
+test_that("a vcov argument passed as a variable is not read as non-iid", {
+  build <- function(formula, data, vcov = "iid") {
+    fixest::feols(fml = formula, data = data, vcov = vcov)
+  }
+  model <- build(fml, darfur)
+
+  # the call holds the symbol `vcov`, not the string it evaluated to
+  expect_true(is.symbol(model$call$vcov))
+
+  expect_silent(adjusted_se(model, treatment = "directlyharmed",
+                            r2dz.x = 0.05, r2yz.dx = 0.05))
+  expect_silent(adjusted_t(model, treatment = "directlyharmed",
+                           r2dz.x = 0.05, r2yz.dx = 0.05))
+  expect_silent(adjusted_ci(model, treatment = "directlyharmed",
+                            r2dz.x = 0.05, r2yz.dx = 0.05))
+})
+
+# =========================================================================
+# ovb_bounds computes both an adjusted se and an adjusted t. The note
+# belongs to the model, not to each statistic, so it must appear once.
+# =========================================================================
+
+count_notes <- function(expr) {
+  notes <- character()
+  withCallingHandlers(
+    expr,
+    message = function(m) {
+      notes <<- c(notes, conditionMessage(m))
+      invokeRestart("muffleMessage")
+    })
+  sum(grepl("iid", notes))
+}
+
+test_that("the note is emitted once per call, not once per statistic", {
+  expect_equal(count_notes(
+    ovb_bounds(feols.hc1, treatment = "directlyharmed",
+               benchmark_covariates = "female", kd = 1)), 1)
+
+  expect_equal(count_notes(
+    ovb_extreme_plot(feols.hc1, treatment = "directlyharmed",
+                     benchmark_covariates = "female", kd = 1)), 1)
+
+  expect_equal(count_notes({
+    ovb_contour_plot(feols.hc1, treatment = "directlyharmed")
+    add_bound_to_contour(feols.hc1, treatment = "directlyharmed",
+                         benchmark_covariates = "female", kd = 1)
+  }), 1)
+
+  expect_silent(ovb_bounds(feols.hc1, treatment = "directlyharmed",
+                           benchmark_covariates = "female", kd = 1,
+                           message = FALSE))
+})


### PR DESCRIPTION
## Summary

The note that tells fixest users their sensitivity statistics are computed from classical standard errors was misfiring in two ways. Both are fixed here, along with tests for the entry points that had no message coverage.

### 1. The note fired on models that did not warrant it

`adjusted_se.fixest`, `adjusted_ci.fixest` and `adjusted_t.fixest` each decided whether a model used a robust vcov by reading `model$call$vcov`. That is the unevaluated call argument, not the value.

When the vcov arrives through a variable, which is exactly what the formula methods do internally via `fixest::feols(fml = formula, data = data, vcov = vcov)`, that element holds the symbol `vcov` rather than the string it evaluated to. In R, `as.name("vcov") != "iid"` returns `TRUE`, so the check concluded the model used a robust vcov and emitted the note on a model fitted with classical standard errors.

The same mechanism was blind to a vcov chosen any way other than an explicit literal in the call, including `setFixest_vcov()` and fixest's own defaults, since none of those appear in `$call`.

All three now call `message_vcov.fixest()`, which reads the vcov type fixest actually computed.

### 2. The note printed twice per call

`ovb_bounds.fixest` computes an adjusted standard error and an adjusted t-statistic, and passed `message` to both, so each call emitted the note twice. It now emits once before dispatching and passes `message = FALSE` downstream, matching how `sensemakr.fixest` already handles this.

This affected `ovb_bounds()`, `ovb_extreme_plot()` and `add_bound_to_contour()`.

### Behaviour change

`ovb_contour_plot()` on a non-iid model now emits the note once, where it previously emitted none. It had been silent only because it passes `adjusted_estimates = FALSE` and so never reached the messaging code, not because the note was unwanted. Its bounds are computed from classical standard errors, so the note belongs there. No existing test relied on the previous silence.

## Tests

New file `tests/testthat/test-25-vcov-message.R`, covering:

- `sensemakr.fixest` and `sensitivity_stats.fixest` emit the note for a non-iid vcov. Neither had any message assertion previously, which is why the fixest 0.14.0 regression fixed in #60 went undetected on eight of nine CI jobs.
- No note for an iid model.
- No note when the vcov argument is passed through a variable.
- Exactly one note per call from `ovb_bounds`, `ovb_extreme_plot` and `add_bound_to_contour`.

## Verification

Built fixest 0.11.1 and 0.14.2 from source and ran all assertions against both. All pass on both. Numeric output is unchanged: for `ovb_bounds(feols_hc1, treatment = "directlyharmed", benchmark_covariates = "female", kd = 1)`, the adjusted estimate is 0.07522027121, the adjusted standard error 0.02187332774, and the adjusted t 3.43890386, identical across both fixest versions and unchanged from before this diff.

Also gitignores `Rplots.pdf` at the repository root. `.gitignore` covered only the `tests/testthat` copy, so the root one previously had to be removed by hand in 0a6c7dd.

## Test plan

- [x] Assertions pass on fixest 0.14.2
- [x] Assertions pass on fixest 0.11.1
- [x] Numeric output unchanged
- [ ] Full `R CMD check` across all nine CI jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSihWtxwCkfu3vdftqssNB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSihWtxwCkfu3vdftqssNB)_