### PR TITLE
Make the formula methods work outside the global environment

### DIFF
--- a/R/ovb_plots.R
+++ b/R/ovb_plots.R
@@ -414,8 +414,7 @@ ovb_contour_plot.formula = function(formula,
   type <- match.arg(method, method)
 
   if(type == "lm") {
-    reg.call <- call(type, formula = substitute(formula), data = substitute(data))
-    outcome_model = eval(reg.call)
+    outcome_model <- lm(formula, data)
   } else if(type == "feols") {
     if (!requireNamespace("fixest", quietly = TRUE)) {
       stop("Please install the fixest package.")
@@ -1232,8 +1231,7 @@ ovb_extreme_plot.formula = function(formula,
   type <- match.arg(method, method)
 
   if(type == "lm") {
-    reg.call <- call(type, formula = substitute(formula), data = substitute(data))
-    outcome_model = eval(reg.call)
+    outcome_model <- lm(formula, data)
   } else if(type == "feols") {
     if (!requireNamespace("fixest", quietly = TRUE)) {
       stop("Please install the fixest package.")

--- a/R/sensemakr.R
+++ b/R/sensemakr.R
@@ -407,8 +407,7 @@ sensemakr.formula <- function(formula,
   type <- match.arg(method, method)
 
   if(type == "lm") {
-    reg.call <- call(type, formula = substitute(formula), data = substitute(data))
-    outcome_model <- eval(reg.call)
+    outcome_model <- lm(formula, data)
   } else if(type == "feols") {
     if (!requireNamespace("fixest", quietly = TRUE)) {
       stop("Please install the fixest package.")

--- a/tests/testthat/test-27-formula-environment.R
+++ b/tests/testthat/test-27-formula-environment.R
@@ -1,0 +1,110 @@
+context("The formula interface works away from the global environment")
+
+data("darfur")
+
+fml <- peacefactor ~ directlyharmed + age + female
+
+null_device <- function(expr) {
+  pdf(NULL)
+  on.exit(dev.off(), add = TRUE)
+  force(expr)
+}
+
+# =========================================================================
+# The formula methods used to rebuild the lm() call out of substitute() and
+# evaluate it with no environment, which resolves in the method's own frame
+# and from there only along the lexical chain to the global environment. Any
+# data frame living in a calling frame was therefore invisible.
+# =========================================================================
+
+test_that("sensemakr.formula finds a data frame passed as an argument", {
+  f <- function(dat) {
+    sensemakr(fml, data = dat, method = "lm", treatment = "directlyharmed")
+  }
+  expect_s3_class(f(darfur), "sensemakr")
+})
+
+test_that("sensemakr.formula finds a data frame held in a local variable", {
+  g <- function() {
+    d <- darfur
+    sensemakr(fml, data = d, method = "lm", treatment = "directlyharmed")
+  }
+  expect_s3_class(g(), "sensemakr")
+})
+
+test_that("the data frame is found through nesting and through lapply", {
+  one <- function(dat) sensemakr(fml, data = dat, method = "lm",
+                                 treatment = "directlyharmed")
+  two <- function(dat) one(dat)
+  expect_s3_class(two(darfur), "sensemakr")
+
+  out <- lapply(list(darfur), function(dat)
+    sensemakr(fml, data = dat, method = "lm", treatment = "directlyharmed"))
+  expect_s3_class(out[[1]], "sensemakr")
+})
+
+test_that("a formula built in a calling frame is found", {
+  k <- function() {
+    local_fml <- peacefactor ~ directlyharmed + age + female
+    sensemakr(local_fml, data = darfur, method = "lm",
+              treatment = "directlyharmed")
+  }
+  expect_s3_class(k(), "sensemakr")
+})
+
+test_that("both plot formula methods work from inside a function", {
+  cp <- function(dat) ovb_contour_plot(formula = fml, data = dat, method = "lm",
+                                       treatment = "directlyharmed",
+                                       benchmark_covariates = "female", kd = 1)
+  ep <- function(dat) ovb_extreme_plot(formula = fml, data = dat, method = "lm",
+                                       treatment = "directlyharmed",
+                                       benchmark_covariates = "female", kd = 1)
+  expect_silent(null_device(cp(darfur)))
+  expect_silent(null_device(ep(darfur)))
+})
+
+# =========================================================================
+# The formula interface must agree with the model interface exactly, and
+# must keep doing so from inside a function.
+# =========================================================================
+
+test_that("benchmark bounds match the lm interface exactly", {
+  model <- lm(fml, data = darfur)
+  ref <- ovb_bounds(model, treatment = "directlyharmed",
+                    benchmark_covariates = c("female", "age"), kd = c(1, 2, 3))
+
+  top <- sensemakr(fml, data = darfur, method = "lm",
+                   treatment = "directlyharmed",
+                   benchmark_covariates = c("female", "age"), kd = c(1, 2, 3))
+  expect_equal(as.data.frame(ref), as.data.frame(top$bounds), tolerance = 0)
+
+  inside <- function(dat) {
+    sensemakr(fml, data = dat, method = "lm", treatment = "directlyharmed",
+              benchmark_covariates = c("female", "age"), kd = c(1, 2, 3))
+  }
+  expect_equal(as.data.frame(ref), as.data.frame(inside(darfur)$bounds),
+               tolerance = 0)
+})
+
+test_that("group benchmark bounds match the lm interface exactly", {
+  model <- lm(fml, data = darfur)
+  grp <- list(grp = c("female", "age"))
+  ref <- ovb_bounds(model, treatment = "directlyharmed",
+                    benchmark_covariates = grp, kd = 2)
+  out <- sensemakr(fml, data = darfur, method = "lm",
+                   treatment = "directlyharmed",
+                   benchmark_covariates = grp, kd = 2)
+  expect_equal(as.data.frame(ref), as.data.frame(out$bounds), tolerance = 0)
+})
+
+# =========================================================================
+# The returned object no longer carries the method's own frame, and with it
+# the fitted model and a copy of the data, through the stored formula.
+# =========================================================================
+
+test_that("the returned object does not retain the method's internals", {
+  s <- sensemakr(peacefactor ~ directlyharmed + age + female, data = darfur,
+                 method = "lm", treatment = "directlyharmed")
+  env <- environment(s$info$formula)
+  expect_false(any(c("outcome_model", "reg.call") %in% ls(env)))
+})


### PR DESCRIPTION
`sensemakr.formula`, `ovb_contour_plot.formula` and `ovb_extreme_plot.formula` each rebuilt the `lm()` call from `substitute(formula)` and `substitute(data)` and then evaluated it with `eval(reg.call)`, passing no environment.

```r
reg.call <- call(type, formula = substitute(formula), data = substitute(data))
outcome_model <- eval(reg.call)
```

`substitute()` returns the bare symbol the caller wrote and discards the environment it belongs to. `eval()`'s default `envir = parent.frame()` is resolved inside `eval` itself, so it means the caller of `eval` — the method's own frame. From there R falls back to lexical scoping through the package namespace to the global environment, and the caller's frame never appears on that chain.

Any data frame or formula held in a calling frame was therefore invisible:

```r
f <- function(dat) sensemakr(fml, data = dat, method = "lm",
                             treatment = "directlyharmed")
f(darfur)
#> Error in eval(mf, parent.frame()) : object 'dat' not found
```

## What worked and what did not

A call naming a global object resolved, because the global environment *is* on the lexical chain. That is why the examples and vignettes never saw this.

| Call | Before |
|---|---|
| `sensemakr(fml, data = darfur, ...)` | works |
| `data = subset(darfur, female == 1)` | works |
| `data = sets[["a"]]` | works |
| inside a function, `data` a local variable | `object not found` |
| inside a function, `data` an argument | `object not found` |
| argument forwarded one level further | `object not found` |
| inside `lapply` over a list of data frames | `object not found` |
| formula built inside the function | `object not found` |

Plain `lm()` handles every one of these, so this was not something R forces on a wrapper.

## The fix

Call `lm(formula, data)` directly, which is what the `feols` branch four lines below has always done and why that branch was unaffected.

[Advanced R §20.6](https://adv-r.hadley.nz/evaluation.html) recommends against building the call at all in this situation — *"I don't think this technique is a good idea because you can achieve the same result without NSE."* The technique exists so that a wrapper's `print(model)` shows the user's arguments rather than the wrapper's, and nothing in this package reads or displays the fitted model's stored call. The alternative, if that ever changes, is `eval(reg.call, parent.frame())`, which keeps the expression and adds back the environment; it was tested alongside this one and behaves identically on everything below.

## Side effect: the returned object stops carrying the method's frame

`out$info$formula` stores `formula(model)`, and a formula keeps a reference to the environment it was built in. Under the old code that was the inside of the method, so the returned object held the fitted model, a copy of the data and every other local:

```r
s <- sensemakr(peacefactor ~ directlyharmed + age + female, data = darfur,
               method = "lm", treatment = "directlyharmed")
ls(environment(s$info$formula))
#>  [1] "alpha" "benchmark_covariates" "bound_label" "data" "formula" ...
#> [14] "reg.call" "treatment" "type" "vcov"
```

Not a leak — it is freed with the object, and no larger than what a plain `lm` already carries — but the object was heavier than its three components suggest. After this change the formula's environment is wherever the caller built it and nothing is retained.

## Verification

- Benchmark bounds through the formula interface are **identical to the model interface at `tolerance = 0`**, for ordinary benchmarks, group benchmarks, and both plot methods. `ovb_bounds.lm` builds its treatment regression from `model.matrix(model)` rather than refitting, so it never reads the call or the original data and cannot be affected.
- Test suite: **327 passing, 0 failures**, up from 310. fixest is not installable in the environment I ran in, so the 13 files that need it were not run locally; CI covers them.
- `tests/testthat/test-27-formula-environment.R` adds a regression test for each calling shape in the table above, two tests pinning the formula-interface bounds to the model-interface bounds at zero tolerance, and one asserting the returned object no longer carries the method's internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSihWtxwCkfu3vdftqssNB

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSihWtxwCkfu3vdftqssNB)_